### PR TITLE
Fix empty store after migration

### DIFF
--- a/PBDCoreDataMigrationAssistant/Classes/Lib/PBDCoreDataMigrationAssistant.m
+++ b/PBDCoreDataMigrationAssistant/Classes/Lib/PBDCoreDataMigrationAssistant.m
@@ -31,10 +31,20 @@
 
     NSAssert(mappingModel, @"No mapping model for migration assistant was provided.");
 
-    NSString *temporaryFilePath = [[self.storeURL relativePath] stringByAppendingString:@"-temporary"];
-    NSURL *temporaryFileURL = [NSURL fileURLWithPath:temporaryFilePath];
+    NSURL *storeDirectory = [self.storeURL URLByDeletingLastPathComponent];
+
+    NSString *shmPath = [[self.storeURL relativePath] stringByAppendingString:@"-shm"];
+    NSURL *shmURL = [NSURL fileURLWithPath:shmPath];
+    NSString *walPath = [[self.storeURL relativePath] stringByAppendingString:@"-wal"];
+    NSURL *walURL = [NSURL fileURLWithPath:walPath];
+	
+    NSURL *temporaryFileURL = [storeDirectory URLByAppendingPathComponent:@"tmp.sqlite"];
+    NSURL *temporaryShmURL = [storeDirectory URLByAppendingPathComponent:@"tmp.sqlite-shm"];
+    NSURL *temporaryWalURL = [storeDirectory URLByAppendingPathComponent:@"tmp.sqlite-wal"];
 
     [self.fileManager moveItemAtURL:self.storeURL toURL:temporaryFileURL error:nil];
+    [self.fileManager moveItemAtURL:shmURL toURL:temporaryShmURL error:nil];
+    [self.fileManager moveItemAtURL:walURL toURL:temporaryWalURL error:nil];
 
     NSMigrationManager *migrationManager = [[NSMigrationManager alloc] initWithSourceModel:self.sourceModel
                                                                           destinationModel:self.destinationModel];
@@ -50,6 +60,8 @@
                                                                error:&migrationError];
 
     [self.fileManager removeItemAtURL:temporaryFileURL error:nil];
+    [self.fileManager removeItemAtURL:temporaryShmURL error:nil];
+    [self.fileManager removeItemAtURL:temporaryWalURL error:nil];
 
     if (error) {
         *error = migrationError;


### PR DESCRIPTION
Currently when the MigrationAssistant performs migration it results in empty store (even for lightweight migration). That happens because during migration the sqlite file (e.g. Store.sqlite) is being renamed to Store.sqlite-temporary and then passed to 'migrateStoreFromURL' as a sourceURL. It seems that 'migrateStoreFromURL' needs also 'shm' and 'wal' counterparts to get things done properly.

Proposed solution:

Assuming we've got following files:
`Store.sqlite`
`Store.sqlite-shm`
`Store.sqlite-wal`

First rename them into:
`tmp.sqlite`
`tmp.sqlite-shm`
`tmp.sqlite-wal`

Then use `tmp.sqlite` as a sourceURL, `Store.sqlite` as a desinationURL

And finally remove all three tmp files.
